### PR TITLE
Kasvojentunnistusta simuloiva node

### DIFF
--- a/sop-robot.code-workspace
+++ b/sop-robot.code-workspace
@@ -94,6 +94,18 @@
 			"/ros2_control_ws/install/controller_manager_msgs/lib/python3.8/site-packages",
 			"/ros2_control_ws/install/control_msgs/lib/python3.8/site-packages",
 			"/opt/ros/foxy/lib/python3.8/site-packages"
+		],
+		"python.analysis.extraPaths": [
+			"/workspace/install/head_gestures/lib/python3.8/site-packages",
+			"/workspace/install/face_tracker/lib/python3.8/site-packages",
+			"/workspace/install/example/lib/python3.8/site-packages",
+			"/workspace/install/dynamixel_workbench_msgs/lib/python3.8/site-packages",
+			"/moveit2_ws/install/warehouse_ros_mongo/lib/python3.8/site-packages",
+			"/moveit2_ws/install/moveit_msgs/lib/python3.8/site-packages",
+			"/ros2_control_ws/install/ros2controlcli/lib/python3.8/site-packages",
+			"/ros2_control_ws/install/controller_manager_msgs/lib/python3.8/site-packages",
+			"/ros2_control_ws/install/control_msgs/lib/python3.8/site-packages",
+			"/opt/ros/foxy/lib/python3.8/site-packages"
 		]
 	}
 }

--- a/src/face_tracker/face_tracker/mock_face_tracker_node.py
+++ b/src/face_tracker/face_tracker/mock_face_tracker_node.py
@@ -1,0 +1,72 @@
+import rclpy
+from ament_index_python.packages import get_package_share_directory
+
+from rclpy.node import Node
+
+from std_msgs.msg import String
+from face_tracker_msgs.msg import Point2
+
+
+class FaceTracker(Node):
+    def __init__(self):
+        super().__init__("mock_face_tracker")
+
+        self.face_location_publisher = self.create_publisher(Point2, 'face_tracker/face_location_topic', 10)
+
+        self.face_location = None  # Variable for face location
+
+        self.get_logger().info("Mock face tracker initialized")
+
+
+    def publish_face_location(self):
+        # Check that there is a location to publish
+        if self.face_location:
+            # Publish face location
+            self.face_location_publisher.publish(self.face_location)
+            # Set location back to None to prevent publishing same location multiple times
+            self.face_location = None
+
+    def parse_coordinates(self, command):
+        if ',' in command:
+            x, y = command.split(',')
+        elif ' ' in command:
+            x, y = command.split(' ')
+        else:
+            return None
+        return [int(x), int(y)]      
+
+    def send_coordinates(self, command):
+        coordinates = self.parse_coordinates(command)
+        if coordinates:
+            self.face_location = Point2(x=coordinates[0], y=coordinates[1])
+            self.publish_face_location()
+            return True
+        else:
+            return False
+
+
+def main(args=None):
+    # Initialize
+    rclpy.init(args=args)
+    tracker = FaceTracker()
+    
+    command = None
+    print("Input coordinates")
+    while command != "exit":
+        try:
+            command = input("> ").lower()
+            success = tracker.send_coordinates(command)
+            if not success and command != "exit":
+                raise ValueError
+        except (ValueError, TypeError):
+            print(
+                'Usage: Input the x- and y-coordinates on a single line separated by a comma or a space. The coordinates must be integers. Input the command "exit" to exit the program'
+                )
+
+    # Shutdown
+    tracker.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/face_tracker/readme.md
+++ b/src/face_tracker/readme.md
@@ -1,5 +1,5 @@
 
-This package contains a node that publishes image with the detected faces for debugging purposes and a message that contains location and landmarks of the detected faces.
+This package contains a node that publishes image with the detected faces for debugging purposes and a message that contains location and landmarks of the detected faces. For the purpose of testing other functionality, such as eye movements, separately from face tracking, a mock face tracker node is also included.
 
 ![](./img/example.png)
 
@@ -23,8 +23,18 @@ ros2 launch face_tracker face_tracker.test.launch.py
 
 To view the camera feed, run: `ros2 run rqt_image_view rqt_image_view` and select the appropriate topic from the list.
 
+
+The following launches the mock face tracker node.
+
+```console
+ros2 run face_tracker mock_face_tracker_node
+```
+To use it, simply enter the desired coordinates on a single line, separated by either a comma or a space. The coordinates will then be published as a detected face location.
+
+
 ## Dependencies
 
+(Not required for the mock face tracker)
 * `Video4Linux2`
 * `dlib`
 * `opencv-python`

--- a/src/face_tracker/setup.py
+++ b/src/face_tracker/setup.py
@@ -25,7 +25,8 @@ setup(
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
-            'face_tracker_node = face_tracker.face_tracker_node:main'
+            'face_tracker_node = face_tracker.face_tracker_node:main',
+            'mock_face_tracker_node = face_tracker.mock_face_tracker_node:main',
         ],
     },
 )


### PR DESCRIPTION
Käynnistyy komennolla "ros2 run face_tracker mock_face_tracker_node". Tämän jälkeen voi kirjoittaa haluamansa koordinaatit pilkulla tai välilyönnillä erotettuna, ja ne julkaistaan saman kanavan kautta kuin tavallisessa kasvojentunnistuksessakin. "Exit"-komennolla poistuu.